### PR TITLE
Add message about current downtime to replace "Application error" message

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html>
+<head>
+  <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+  <style type="text/css">
+    html, body { margin: 0; padding: 0; height: 100%; font-family: sans-serif;}
+  </style>
+<title>Travis-CI Weblint currently unavailable</title></head>
+</head>
+<body>
+  <div style="width: 600px; max-width: 1000px; min-width: 600px; width: 80%; margin: 50px auto 0;">
+      <h1>Travis-CI Weblint is currently unavailable</h1>
+      <div>
+         Due to a security issue, the web version of our lint tool is currently not available.<br /><br />
+         We're already working on it and will try to bring it back as soon as we can!
+      </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Add a message explaining that the travis team knows about the weblint being down
and is working on bringing it back.

There have been numerous duplicate error reports about it, since the app
currently displays "Application error". This should prevent more of those.

Unfortunately, I don't know how ruby web-apps work or are built, so I don't know where exactly to place the `index.html` with the downtime message.
Feel free to put it in the right place, or tell me where and I'll move it ;)
