### PR TITLE
Link to new WebLint tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ travis-weblint
 
 This version of WebLint is deprecated.
 
-We are working on a new yml parsing library, <a href="https://github.com/travis-ci/travis-yml">travis-yml</a>, which is slowly being rolled out on the Travis CI hosted platform. We are also working on a new WebLint tool.
+We are working on a new yml parsing library, <a href="https://github.com/travis-ci/travis-yml">travis-yml</a>, which is slowly being rolled out on the Travis CI hosted platform. We are also working on a new WebLint tool at <a href="http://config.travis-ci.org/">config.travis-ci.org</a>.
 
 For more information about opting in to use `travis-yml` in your Travis builds please contact <a href="mailto:support@travis-ci.com">support@travis-ci.com</a>

--- a/web.rb
+++ b/web.rb
@@ -30,7 +30,7 @@ html
       | This version of WebLint is deprecated.
       br
       br
-      | We are working on a new yml parsing library, <a href="https://github.com/travis-ci/travis-yml">travis-yml</a>, which is slowly being rolled out on the Travis CI hosted platform. We are also working on a new WebLint tool.
+      | We are working on a new yml parsing library, <a href="https://github.com/travis-ci/travis-yml">travis-yml</a>, which is slowly being rolled out on the Travis CI hosted platform. We are also working on a new WebLint tool at <a href="http://config.travis-ci.org/">config.travis-ci.org</a>.
       br
       br
       | For more information about opting in to use `travis-yml` in your Travis builds please contact <a href="mailto:support@travis-ci.com">support@travis-ci.com</a>


### PR DESCRIPTION
From a support email thread:

> Our team is currently working on a new linter (with the new travis-yml tool) that is available at http://config.travis-ci.org/ - please note that this is a WIP and the tool might change. As soon as this is ready to go, we'll make sure it's documented in a visible place :-)

This PR creates the link to the new tool.